### PR TITLE
fix: interpret aarch64 as arm64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ get_arch() {
     amd64 | x86_64)
       echo "amd64"
       ;;
-    arm64)
+    arm64 | aarch64)
       echo "arm64"
       ;;
     i386 | i686)


### PR DESCRIPTION
This is something of an edge case, but `uname -m` will return "aarch64" in a ubuntu container building off of a Apple ARM.  

This should pull the arm64 artifact and not return the empty-string, which will error.